### PR TITLE
third-parties: add to third parties list for pentesting

### DIFF
--- a/third-parties.md
+++ b/third-parties.md
@@ -9,6 +9,7 @@ We may share your information with:
 	- payment handling
 	- product development
 	- risk modelling
+	- security testing
 	- soft credit checks
 	- transactional messages
 - underwriters of any policies you purchase


### PR DESCRIPTION
Added that we may share information with third parties for reasons of security testing, eg pentests.